### PR TITLE
Use Dockerfile to build clio and dependencies

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:20.04 AS deps
+
+ARG BOOST_VERSION=1.75.0
+ARG CMAKE_VERSION=3.16.3
+
+RUN apt-get update && apt-get install -y build-essential curl
+
+COPY build_boost.sh .
+RUN ./build_boost.sh ${BOOST_VERSION}
+ENV BOOST_ROOT=/boost
+
+COPY install_cmake.sh .
+RUN ./install_cmake.sh ${CMAKE_VERSION}
+
+FROM ubuntu:20.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=deps /boost /boost
+COPY --from=deps /*.log /
+ENV BOOST_ROOT=/boost
+
+COPY --from=deps /opt/cmake/ /opt/cmake/
+ENV PATH="/opt/cmake/bin:$PATH"
+
+RUN apt-get update && apt-get install -y git make software-properties-common pkg-config libssl-dev zlib1g-dev bison flex autoconf
+
+COPY install_compilers.sh .
+ARG CC=gcc
+RUN ./install_compilers.sh "${CC}"
+
+RUN apt-get clean
+COPY build_clio.sh /build_clio.sh
+RUN chmod +x /build_clio.sh
+ENTRYPOINT ["/build_clio.sh"]

--- a/build/action.yml
+++ b/build/action.yml
@@ -3,5 +3,4 @@ description: 'Build clio'
 
 runs:
   using: 'docker'
-  image: 'docker://legleux/ct' # the clio_builder docker image TODO: change this to local Dockerfile or from docker repo?
-  entrypoint: ./gha/build/build_clio.sh
+  image: 'Dockerfile'

--- a/build/build_boost.sh
+++ b/build/build_boost.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -exu
+
+BOOST_VERSION=$1
+BOOST_VERSION_=$(echo ${BOOST_VERSION} | tr . _)
+echo "BOOST_VERSION: ${BOOST_VERSION}"
+curl -OJLs "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_}.tar.gz"
+tar zxf "boost_${BOOST_VERSION_}.tar.gz"
+cd boost_${BOOST_VERSION_} && ./bootstrap.sh | tee -a /boost_build.log && ./b2 -j$(nproc) | tee -a /boost_build.log 2>&1
+mkdir -p /boost && mv boost /boost && mv stage /boost

--- a/build/build_clio.sh
+++ b/build/build_clio.sh
@@ -4,6 +4,6 @@ export SRC_DIR=$(realpath clio_src)
 echo "[${SRC_DIR}] passed to Clio repo as SRC_DIR"
 
 cmake -S clio_ci -B clio_ci/build -DSRC_DIR=$SRC_DIR
-cmake --build clio_ci/build --parallel $(nproc)
-
-cp /github/workspace/clio_ci/build/clio-prefix/src/clio-build/clio_tests .
+cmake --build clio_ci/build --parallel $(nproc) | tee -a clio_build.log
+cp /*.log . # get the boost build logs
+cp ./clio_ci/build/clio-prefix/src/clio-build/clio_tests .

--- a/build/install_cmake.sh
+++ b/build/install_cmake.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CMAKE_VERSION=$1
+URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"
+curl -OJLs $URL
+tar xzf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+mv /cmake-${CMAKE_VERSION}-Linux-x86_64/ /opt/cmake/

--- a/build/install_compilers.sh
+++ b/build/install_compilers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CC=$1
+
+if [ $CC = gcc ]; then
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    apt-get update && apt-get install -y gcc-11 g++-11
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
+        --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
+        --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11
+elif [$CC = clang]; then
+    apt-get -y install clang clang-12
+fi

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -1,6 +1,7 @@
 runs:
   using: composite
   steps:
+    # Github's ubuntu-20.04 image already has clang-format-11 installed
     - run: |
         find src unittests -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-11 -i
       shell: bash


### PR DESCRIPTION
Accepting this PR will start building clio with GCC 11 from a dockerfile checked into this repo.
Eventually this Dockerfile should be sourced from the clio source repo itself.

[Run utilizing this version of the action](https://github.com/legleux/clio/actions/runs/2735774033)
